### PR TITLE
feat: add validation for rollback_candidate_retain_count >= 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ test-clean:  ## Run a test and destroy resources
 
 .PHONY: bootstrap
 bootstrap: install-hooks ## bootstrap the development environment
-	pip install -U "pip ~= 23.1"
-	pip install -U "setuptools ~= 68.0"
+	pip install -U "pip ~= 26.0"
+	pip install -U "setuptools ~= 82.0"
 	pip install -r requirements.txt
 
 .PHONY: clean

--- a/policy.tf
+++ b/policy.tf
@@ -94,7 +94,7 @@ resource "aws_ecr_lifecycle_policy" "repo" {
     precondition {
       condition = (
         var.expire_days_tagged == null && var.expire_count_tagged == null
-        ) || (
+        ) ? true : (
         var.tag_prefix_list != null || var.tag_pattern_list != null
       )
       error_message = "tag_prefix_list or tag_pattern_list is required when expire_days_tagged or expire_count_tagged is set."

--- a/policy.tf
+++ b/policy.tf
@@ -89,4 +89,15 @@ data "aws_ecr_lifecycle_policy_document" "repo" {
 resource "aws_ecr_lifecycle_policy" "repo" {
   repository = aws_ecr_repository.repo.name
   policy     = data.aws_ecr_lifecycle_policy_document.repo.json
+
+  lifecycle {
+    precondition {
+      condition = (
+        var.expire_days_tagged == null && var.expire_count_tagged == null
+        ) || (
+        var.tag_prefix_list != null || var.tag_pattern_list != null
+      )
+      error_message = "tag_prefix_list or tag_pattern_list is required when expire_days_tagged or expire_count_tagged is set."
+    }
+  }
 }

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -39,27 +39,17 @@ def test_module(
 
     # Write terraform.tfvars
     with open(osp.join(terraform_dir, "terraform.tfvars"), "w") as fp:
-        fp.write(
-            dedent(
-                f"""
+        fp.write(dedent(f"""
                 region          = "{aws_region}"
-                """
-            )
-        )
+                """))
         if test_role_arn:
-            fp.write(
-                dedent(
-                    f"""
+            fp.write(dedent(f"""
                     role_arn      = "{test_role_arn}"
-                    """
-                )
-            )
+                    """))
 
     # Update terraform.tf with the specific AWS provider version
     with open(osp.join(terraform_dir, "terraform.tf"), "w") as fp:
-        fp.write(
-            dedent(
-                f"""
+        fp.write(dedent(f"""
                 terraform {{
                   required_providers {{
                     aws = {{
@@ -68,9 +58,7 @@ def test_module(
                     }}
                   }}
                 }}
-                """
-            )
-        )
+                """))
     with terraform_apply(
         terraform_dir,
         destroy_after=not keep_after,

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "rollback_candidate_retain_count" {
 
   validation {
     condition     = var.rollback_candidate_retain_count == null ? true : var.rollback_candidate_retain_count >= 2
-    error_message = "rollback_candidate_retain_count must be >= 2 (or null to disable). A value of 1 is dangerous: it keeps only the current deployment, so the previous (possibly still active) image would be pruned."
+    error_message = "rollback_candidate_retain_count must be >= 2 (or null to disable). Values below 2 risk pruning the currently active image."
   }
 }
 
@@ -93,6 +93,11 @@ variable "rollback_candidate_retain_days" {
   EOT
   type        = number
   default     = null
+
+  validation {
+    condition     = var.rollback_candidate_retain_days == null ? true : var.rollback_candidate_retain_days >= 1
+    error_message = "rollback_candidate_retain_days must be >= 1 (or null to disable)."
+  }
 }
 
 variable "expire_days_tagged" {

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,11 @@ variable "rollback_candidate_retain_count" {
   EOT
   type        = number
   default     = null
+
+  validation {
+    condition     = var.rollback_candidate_retain_count == null ? true : var.rollback_candidate_retain_count >= 2
+    error_message = "rollback_candidate_retain_count must be >= 2 (or null to disable). A value of 1 is dangerous: it keeps only the current deployment, so the previous (possibly still active) image would be pruned."
+  }
 }
 
 variable "rollback_candidate_retain_days" {


### PR DESCRIPTION
A value of 1 would only keep the current deployment, allowing the
previous (possibly still active) image to be pruned by lifecycle
policy.
